### PR TITLE
Store controller config as a secret

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
     spec:
       volumes:
       - name: config
-        configMap:
-          name: {{ include "chart.fullname" . }}-manager-config
+        secret:
+          secretName: {{ include "chart.fullname" . }}-manager-config
       containers:
       - args: {{- toYaml .Values.controllerManager.kubeRbacProxy.args | nindent 8 }}
         env:
@@ -46,6 +46,7 @@ spec:
         volumeMounts:
         - mountPath: /beamlit/config.yaml
           name: config
+          readOnly: true
           subPath: config.yaml
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN

--- a/chart/templates/manager-configmap.yaml
+++ b/chart/templates/manager-configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ include "chart.fullname" . }}-manager-config
   namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |
-    {{ .Values.config | toYaml | nindent 4 }}
+    {{ .Values.config | toYaml | b64enc }}


### PR DESCRIPTION
Storing the controller config as a secret for the moment. It should be temporary since we need to refactor config to remove some of the secrets located inside.